### PR TITLE
create-upload-and-deploy.sh is an all-in-one deployment script

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ your content. Duplicate titles are permitted.
 
 ```bash
 ./deploy/create-content.sh "Shakespeare Word Clouds"
-# => Created application: 491b772f-a58f-47e0-b358-3da7e288939c
+# => Created content: 491b772f-a58f-47e0-b358-3da7e288939c
 ```
 
 The GUID that is returned (`491b772f-a58f-47e0-b358-3da7e288939c`) identifies
@@ -153,9 +153,42 @@ Shiny application as you incorporate feedback from your colleagues. Publish
 new versions of an R Markdown document as you make edits and expand your
 research.
 
+> You will need to adapt this script for your content. The `bundle.tar.gz`
+> archive file is created by only including the files needed by the Shiny
+> application in this repository.
+
 You cannot convert a content item from one type to another -- R Markdown
 reports cannot become Shiny applications -- create a new content item to
 contain the different type of content.
+
+### Create, upload, and deploy
+
+The `create-upload-and-deploy.sh` script performs the work of both
+`create-content.sh` and `upload-and-deploy.sh` in one command. The
+command-line arguments are taken as the title of your content. Duplicate
+titles are permitted.
+
+```bash
+./deploy/create-upload-and-deploy.sh "Shakespeare Word Clouds"
+# => Creating bundle archive: bundle.tar.gz
+# => Created content: 491b772f-a58f-47e0-b358-3da7e288939c
+# => Created bundle: 468
+# => Deployment task: meQSUN9aqjKexyqN
+# => Building Shiny application...
+# => Bundle requested R version 3.5.1; using /usr/lib/R/bin/R which has version 3.4.4
+# => ...
+# => Completed packrat build against R version: '3.4.4'
+# => Launching Shiny application...
+# => Task: meQSUN9aqjKexyqN Complete.
+```
+
+Use `create-upload-and-deploy.sh` when you do not need to separate the
+creation from upload/deploy phases. Use `upload-and-deploy` script for
+additional deployments to your newly created item.
+
+> You will need to adapt this script for your content. The `bundle.tar.gz`
+> archive file is created by only including the files needed by the Shiny
+> application in this repository.
 
 ## Using Docker for deployments
 
@@ -191,7 +224,7 @@ docker run --rm \
     -w /content \
     rstudio-connect-deployer:latest \
     /content/deploy/create-content.sh "Content created with Docker"
-# => Created application: 3dac1a27-260c-4e56-b8c0-c6f0913d9ac5
+# => Created content: 3dac1a27-260c-4e56-b8c0-c6f0913d9ac5
 ```
 
 The GUID that is returned (`3dac1a27-260c-4e56-b8c0-c6f0913d9ac5`) identifies

--- a/deploy/create-content.sh
+++ b/deploy/create-content.sh
@@ -55,5 +55,5 @@ RESULT=$(curl --silent --show-error -L --max-redirs 0 --fail -X POST \
               -H "Authorization: Key ${CONNECT_API_KEY}" \
               --data "${DATA}" \
               "${CONNECT_SERVER}__api__/v1/experimental/content")
-APP=$(echo "$RESULT" | jq -r .guid)
-echo "Created application: ${APP}"
+CONTENT=$(echo "$RESULT" | jq -r .guid)
+echo "Created content: ${CONTENT}"

--- a/deploy/create-upload-deploy.sh
+++ b/deploy/create-upload-deploy.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+#
+# Create content in RStudio Connect with a given title. Does not prevent the
+# creation of duplicate titles.
+#
+
+#!/usr/bin/env bash
+#
+# Create a bundle, upload that bundle to RStudio Connect, deploy that bundle,
+# then wait for deployment to complete.
+#
+# Run this script from the content root directory.
+#
+
+set -e
+
+if [ -z "${CONNECT_SERVER}" ] ; then
+    echo "The CONNECT_SERVER environment variable is not defined. It defines"
+    echo "the base URL of your RStudio Connect instance."
+    echo 
+    echo "    export CONNECT_SERVER='http://connect.company.com/'"
+    exit 1
+fi
+
+if [[ "${CONNECT_SERVER}" != */ ]] ; then
+    echo "The CONNECT_SERVER environment variable must end in a trailing slash. It"
+    echo "defines the base URL of your RStudio Connect instance."
+    echo 
+    echo "    export CONNECT_SERVER='http://connect.company.com/'"
+    exit 1
+fi
+
+if [ -z "${CONNECT_API_KEY}" ] ; then
+    echo "The CONNECT_API_KEY environment variable is not defined. It must contain"
+    echo "an API key owned by a 'publisher' account in your RStudio Connect instance."
+    echo
+    echo "    export CONNECT_API_KEY='jIsDWwtuWWsRAwu0XoYpbyok2rlXfRWa'"
+    exit 1
+fi
+
+if [ $# -eq 0 ] ; then
+    echo "usage: $0 <content-title>"
+    exit 1
+fi
+
+BUNDLE_PATH="bundle.tar.gz"
+
+# Remove any bundle from previous attempts.
+rm -f "${BUNDLE_PATH}"
+
+# Create an archive with all of our Shiny application source and data.
+#
+# Make sure you bundle the manifest.json and primary content files at the
+# top-level; do not include the containing directory in the archive.
+echo "Creating bundle archive: ${BUNDLE_PATH}"
+tar czf "${BUNDLE_PATH}" manifest.json app.R data
+
+# Only "name" is required by the RStudio Connect API but we use "title" for
+# better presentation. We build a random name to avoid colliding with existing
+# content.
+TITLE="$@"
+
+# Assign a random name. Avoid collisions so we always create something.
+# Inspired by http://tldp.org/LDP/abs/html/randomvar.html
+letters=(a b c d e f g h i j k l m n o p q r s t u v w x y z)
+num_letters=${#letters[*]}
+NAME=$(for((i=1;i<=13;i++)); do printf '%s' "${letters[$((RANDOM%num_letters))]}"; done)
+
+# Build the JSON to create content.
+DATA=$(jq --arg title "${TITLE}" \
+   --arg name  "${NAME}" \
+   '. | .["title"]=$title | .["name"]=$name' \
+   <<<'{}')
+RESULT=$(curl --silent --show-error -L --max-redirs 0 --fail -X POST \
+              -H "Authorization: Key ${CONNECT_API_KEY}" \
+              --data "${DATA}" \
+              "${CONNECT_SERVER}__api__/v1/experimental/content")
+CONTENT=$(echo "$RESULT" | jq -r .guid)
+echo "Created content: ${CONTENT}"
+
+# Upload the bundle
+UPLOAD=$(curl --silent --show-error -L --max-redirs 0 --fail -X POST \
+              -H "Authorization: Key ${CONNECT_API_KEY}" \
+              --data-binary @"${BUNDLE_PATH}" \
+              "${CONNECT_SERVER}__api__/v1/experimental/content/${CONTENT}/upload")
+BUNDLE=$(echo "$UPLOAD" | jq -r .bundle_id)
+echo "Created bundle: $BUNDLE"
+
+# Deploy the bundle.
+DATA=$(jq --arg bundle_id "${BUNDLE}" \
+   '. | .["bundle_id"]=$bundle_id' \
+   <<<'{}')
+DEPLOY=$(curl --silent --show-error -L --max-redirs 0 --fail -X POST \
+              -H "Authorization: Key ${CONNECT_API_KEY}" \
+              --data "${DATA}" \
+              "${CONNECT_SERVER}__api__/v1/experimental/content/${CONTENT}/deploy")
+TASK=$(echo "$DEPLOY" | jq -r .task_id)
+
+# Poll until the task completes.
+FINISHED=false
+CODE=-1
+FIRST=0
+echo "Deployment task: ${TASK}"
+while [ "${FINISHED}" != "true" ] ; do
+    DATA=$(curl --silent --show-error -L --max-redirs 0 --fail \
+              -H "Authorization: Key ${CONNECT_API_KEY}" \
+              "${CONNECT_SERVER}__api__/v1/experimental/tasks/${TASK}?wait=1&first=${FIRST}")
+    # Extract parts of the task status.
+    FINISHED=$(echo "${DATA}" | jq .finished)
+    CODE=$(echo "${DATA}" | jq .code)
+    FIRST=$(echo "${DATA}" | jq .last)
+    # Present the latest output lines.
+    echo "${DATA}" | jq  -r '.output | .[]'
+done
+
+if [ "${CODE}" -ne 0 ]; then
+    ERROR=$(echo "${DATA}" | jq -r .error)
+    echo "Task: ${TASK} ${ERROR}"
+    exit 1
+fi
+echo "Task: ${TASK} Complete."


### PR DESCRIPTION
* uses "created content" rather than "created application" during creation
* add notes about customizing the archive file
* document the all-in-one script