### PR TITLE
Use public API paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ tools. Let us (<sol-eng@rstudio.com>) know about your experience!
    rsconnect::writeManifest()
    ```
 
-   > NOTE: Please use `rsconnect` version 0.8.15 or higher when generating a
+   > NOTE: Please use `rsconnect` version 0.8.16 or higher when generating a
    > manifest file.
 
    We recommend committing the `manifest.json` into your source control system
@@ -163,13 +163,13 @@ contain the different type of content.
 
 ### Create, upload, and deploy
 
-The `create-upload-and-deploy.sh` script performs the work of both
+The `create-upload-deploy.sh` script performs the work of both
 `create-content.sh` and `upload-and-deploy.sh` in one command. The
 command-line arguments are taken as the title of your content. Duplicate
 titles are permitted.
 
 ```bash
-./deploy/create-upload-and-deploy.sh "Shakespeare Word Clouds"
+./deploy/create-upload-deploy.sh "Shakespeare Word Clouds"
 # => Creating bundle archive: bundle.tar.gz
 # => Created content: 491b772f-a58f-47e0-b358-3da7e288939c
 # => Created bundle: 468
@@ -182,7 +182,7 @@ titles are permitted.
 # => Task: meQSUN9aqjKexyqN Complete.
 ```
 
-Use `create-upload-and-deploy.sh` when you do not need to separate the
+Use `create-upload-deploy.sh` when you do not need to separate the
 creation from upload/deploy phases. Use `upload-and-deploy` script for
 additional deployments to your newly created item.
 

--- a/deploy/create-content.sh
+++ b/deploy/create-content.sh
@@ -54,6 +54,6 @@ DATA=$(jq --arg title "${TITLE}" \
 RESULT=$(curl --silent --show-error -L --max-redirs 0 --fail -X POST \
               -H "Authorization: Key ${CONNECT_API_KEY}" \
               --data "${DATA}" \
-              "${CONNECT_SERVER}__api__/v1/experimental/content")
+              "${CONNECT_SERVER}__api__/v1/content")
 CONTENT=$(echo "$RESULT" | jq -r .guid)
 echo "Created content: ${CONTENT}"

--- a/deploy/create-upload-deploy.sh
+++ b/deploy/create-upload-deploy.sh
@@ -74,7 +74,7 @@ DATA=$(jq --arg title "${TITLE}" \
 RESULT=$(curl --silent --show-error -L --max-redirs 0 --fail -X POST \
               -H "Authorization: Key ${CONNECT_API_KEY}" \
               --data "${DATA}" \
-              "${CONNECT_SERVER}__api__/v1/experimental/content")
+              "${CONNECT_SERVER}__api__/v1/content")
 CONTENT=$(echo "$RESULT" | jq -r .guid)
 echo "Created content: ${CONTENT}"
 
@@ -82,8 +82,8 @@ echo "Created content: ${CONTENT}"
 UPLOAD=$(curl --silent --show-error -L --max-redirs 0 --fail -X POST \
               -H "Authorization: Key ${CONNECT_API_KEY}" \
               --data-binary @"${BUNDLE_PATH}" \
-              "${CONNECT_SERVER}__api__/v1/experimental/content/${CONTENT}/upload")
-BUNDLE=$(echo "$UPLOAD" | jq -r .bundle_id)
+              "${CONNECT_SERVER}__api__/v1/content/${CONTENT}/bundles")
+BUNDLE=$(echo "$UPLOAD" | jq -r .id)
 echo "Created bundle: $BUNDLE"
 
 # Deploy the bundle.
@@ -93,7 +93,7 @@ DATA=$(jq --arg bundle_id "${BUNDLE}" \
 DEPLOY=$(curl --silent --show-error -L --max-redirs 0 --fail -X POST \
               -H "Authorization: Key ${CONNECT_API_KEY}" \
               --data "${DATA}" \
-              "${CONNECT_SERVER}__api__/v1/experimental/content/${CONTENT}/deploy")
+              "${CONNECT_SERVER}__api__/v1/content/${CONTENT}/deploy")
 TASK=$(echo "$DEPLOY" | jq -r .task_id)
 
 # Poll until the task completes.
@@ -104,7 +104,7 @@ echo "Deployment task: ${TASK}"
 while [ "${FINISHED}" != "true" ] ; do
     DATA=$(curl --silent --show-error -L --max-redirs 0 --fail \
               -H "Authorization: Key ${CONNECT_API_KEY}" \
-              "${CONNECT_SERVER}__api__/v1/experimental/tasks/${TASK}?wait=1&first=${FIRST}")
+              "${CONNECT_SERVER}__api__/v1/tasks/${TASK}?wait=1&first=${FIRST}")
     # Extract parts of the task status.
     FINISHED=$(echo "${DATA}" | jq .finished)
     CODE=$(echo "${DATA}" | jq .code)

--- a/deploy/upload-and-deploy.sh
+++ b/deploy/upload-and-deploy.sh
@@ -54,8 +54,8 @@ tar czf "${BUNDLE_PATH}" manifest.json app.R data
 UPLOAD=$(curl --silent --show-error -L --max-redirs 0 --fail -X POST \
               -H "Authorization: Key ${CONNECT_API_KEY}" \
               --data-binary @"${BUNDLE_PATH}" \
-              "${CONNECT_SERVER}__api__/v1/experimental/content/${CONTENT}/upload")
-BUNDLE=$(echo "$UPLOAD" | jq -r .bundle_id)
+              "${CONNECT_SERVER}__api__/v1/content/${CONTENT}/bundles")
+BUNDLE=$(echo "$UPLOAD" | jq -r .id)
 echo "Created bundle: $BUNDLE"
 
 # Deploy the bundle.
@@ -65,7 +65,7 @@ DATA=$(jq --arg bundle_id "${BUNDLE}" \
 DEPLOY=$(curl --silent --show-error -L --max-redirs 0 --fail -X POST \
               -H "Authorization: Key ${CONNECT_API_KEY}" \
               --data "${DATA}" \
-              "${CONNECT_SERVER}__api__/v1/experimental/content/${CONTENT}/deploy")
+              "${CONNECT_SERVER}__api__/v1/content/${CONTENT}/deploy")
 TASK=$(echo "$DEPLOY" | jq -r .task_id)
 
 # Poll until the task completes.
@@ -76,7 +76,7 @@ echo "Deployment task: ${TASK}"
 while [ "${FINISHED}" != "true" ] ; do
     DATA=$(curl --silent --show-error -L --max-redirs 0 --fail \
               -H "Authorization: Key ${CONNECT_API_KEY}" \
-              "${CONNECT_SERVER}__api__/v1/experimental/tasks/${TASK}?wait=1&first=${FIRST}")
+              "${CONNECT_SERVER}__api__/v1/tasks/${TASK}?wait=1&first=${FIRST}")
     # Extract parts of the task status.
     FINISHED=$(echo "${DATA}" | jq .finished)
     CODE=$(echo "${DATA}" | jq .code)


### PR DESCRIPTION
This PR updates the scripts to use the upcoming v1 content paths (no longer experimental). We should hold off merging until Connect is released with those public APIs.