### PR TITLE
use an alternate application title

### DIFF
--- a/app.R
+++ b/app.R
@@ -43,7 +43,7 @@ getTermMatrix <- memoise(function(book) {
 
 ui <- fluidPage(
   # Application title
-  titlePanel("Word Cloud"),
+  titlePanel("Shakespearean Word Cloud"),
 
   sidebarLayout(
     # Sidebar with a slider and selection inputs


### PR DESCRIPTION
Distinct from the default "Word Cloud" title to make it more obvious when the "main" version is deployed versus this one.

Do not merge this branch.